### PR TITLE
support for assign and older assign now is destructive assignment

### DIFF
--- a/hulk-compiler/src/lexer.l
+++ b/hulk-compiler/src/lexer.l
@@ -18,6 +18,7 @@ enum Token {
     FALSE,
     PI,
     E,
+    ASSIGN,
     PLUS,
     MINUS,
     TIMES,
@@ -35,7 +36,7 @@ enum Token {
     AND,
     OR,
     NOT,
-    ASSIGN,
+    D_ASSIGN,
     ARROW,
     SEMICOLON,
     COMMA,
@@ -53,7 +54,6 @@ enum Token {
 
 %option c++
 %option noyywrap
-%option debug
 
 DIGIT     [0-9]
 LETTER    [a-zA-Z]
@@ -81,6 +81,7 @@ WS        [ \t\n]
 "PI"            { cout << "PI" << endl; return PI; }
 "E"             { cout << "E" << endl; return E; }
 
+"="             { cout << "ASSIGN" << endl; return ASSIGN; }
 "+"             { cout << "PLUS" << endl; return PLUS; }
 "-"             { cout << "MINUS" << endl; return MINUS; }
 "*"             { cout << "TIMES" << endl; return TIMES; }
@@ -98,7 +99,7 @@ WS        [ \t\n]
 "&"             { cout << "AND" << endl; return AND; }
 "|"             { cout << "OR" << endl; return OR; }
 "!"             { cout << "NOT" << endl; return NOT; }
-":="            { cout << "ASSIGN" << endl; return ASSIGN; }
+":="            { cout << "D_ASSIGN" << endl; return D_ASSIGN; }
 "=>"            { cout << "ARROW" << endl; return ARROW; }
 
 ";"             { cout << "SEMICOLON" << endl; return SEMICOLON; }


### PR DESCRIPTION
This pull request includes changes to the `hulk-compiler/src/lexer.l` file to modify the token definitions and their corresponding actions. The most important changes include adding a new token for assignment, renaming an existing token, and removing a debug option.

Token definition updates:

* Added a new token `ASSIGN` to the `enum Token` list and its corresponding action for the `=` symbol. [[1]](diffhunk://#diff-584b0425141290b2a710c65873ddffc7212730294e2830256c2200332fcdb5a5R21) [[2]](diffhunk://#diff-584b0425141290b2a710c65873ddffc7212730294e2830256c2200332fcdb5a5R84)
* Renamed the `ASSIGN` token to `D_ASSIGN` and updated its corresponding action for the `:=` symbol. [[1]](diffhunk://#diff-584b0425141290b2a710c65873ddffc7212730294e2830256c2200332fcdb5a5L38-R39) [[2]](diffhunk://#diff-584b0425141290b2a710c65873ddffc7212730294e2830256c2200332fcdb5a5L101-R102)

Option changes:

* Removed the `%option debug` from the lexer options.