### PR TITLE
gitignore added, tokens.hh added and moved fro lexer.l

### DIFF
--- a/hulk-compiler/src/lexer.l
+++ b/hulk-compiler/src/lexer.l
@@ -1,55 +1,7 @@
 %{
 #include <iostream>
+#include "../include/tokens.hh"
 using namespace std;
-
-enum Token {
-    FUNCTION = 1,
-    FOR,
-    WHILE,
-    TYPE,
-    INHERITS,
-    NEW,
-    LET,
-    IN,
-    IF,
-    ELIF,
-    ELSE,
-    TRUE,
-    FALSE,
-    PI,
-    E,
-    ASSIGN,
-    PLUS,
-    MINUS,
-    TIMES,
-    DIVIDE,
-    POWER,
-    POW,
-    CONCAT,
-    DCONCAT,
-    EQ,
-    NEQ,
-    LT,
-    GT,
-    LEQ,
-    GEQ,
-    AND,
-    OR,
-    NOT,
-    D_ASSIGN,
-    ARROW,
-    SEMICOLON,
-    COMMA,
-    LPAREN,
-    RPAREN,
-    LBRACE,
-    RBRACE,
-    IDENTIFIER,
-    NUMBER,
-    STRING_LIT,
-    END_OF_FILE
-};
-
 %}
 
 %option c++


### PR DESCRIPTION
This pull request to the `hulk-compiler` project involves changes to the lexer configuration file. The most important change is the removal of the token enumeration, which has been replaced by including a header file that presumably defines these tokens.

Key changes:

* [`hulk-compiler/src/lexer.l`](diffhunk://#diff-584b0425141290b2a710c65873ddffc7212730294e2830256c2200332fcdb5a5R3-L52): Removed the `Token` enumeration and included the `tokens.hh` header file instead. This change simplifies the lexer configuration by centralizing token definitions.